### PR TITLE
fix: use AWS region attribute for provider v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,13 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
 
 ## Modules
 

--- a/locals.tf
+++ b/locals.tf
@@ -8,11 +8,10 @@
 #
 
 locals {
-  region_arr        = split("-", data.aws_region.current.id)
+  region_arr        = split("-", data.aws_region.current.region) # name is deprecated in AWS provider v6; use region instead
   region            = format("%s%s%s", lower(local.region_arr[0]), lower(substr(local.region_arr[1], 0, 2)), lower(local.region_arr[2]))
   system_name       = format("%s-%s-%s-%s-%s", lower(var.org.organization_unit), lower(var.org.environment_name), lower(var.org.environment_type), var.spoke_def, local.region)
   system_name_short = format("%s-%s-%s-%s-%s", substr(lower(var.org.organization_unit), 0, 3), substr(lower(var.org.environment_name), 0, 3), substr(lower(replace(var.org.environment_type, "-", "")), 0, 4), var.spoke_def, local.region)
   all_tags          = merge(module.tags.locals.common_tags, var.extra_tags)
   secret_store_path = format("/%s/%s/%s", lower(var.org.organization_unit), lower(var.org.environment_name), lower(var.org.environment_type))
-
 }

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ locals {
           position = "right"
         }
         period  = 60
-        region  = data.aws_region.current.id
+        region  = data.aws_region.current.region
         stacked = false
         title   = item.title
         view    = "timeSeries"

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,20 @@
 ##
-# (c) 2024 - Cloud Ops Works LLC - https://cloudops.works/
-#            On GitHub: https://github.com/cloudopsworks
-#            Distributed Under Apache v2.0 License
+# (c) 2021-2026
+#     Cloud Ops Works LLC - https://cloudops.works/
+#     Find us on:
+#       GitHub: https://github.com/cloudopsworks
+#       WebSite: https://cloudops.works
+#     Distributed Under Apache v2.0 License
 #
 
-# Establish this is a HUB or spoke configuration
+# is_hub: false # (Optional) Is this a hub or spoke configuration? Default: false
 variable "is_hub" {
   description = "Is this a hub or spoke configuration?"
   type        = bool
   default     = false
 }
 
+# spoke_def: "001" # (Optional) Spoke ID Number, must be a 3 digit number. Default: "001"
 variable "spoke_def" {
   description = "Spoke ID Number, must be a 3 digit number"
   type        = string
@@ -21,6 +25,11 @@ variable "spoke_def" {
   }
 }
 
+# org: # (Required) Organization details
+#   organization_name: "example" # (Required) The name of the organization
+#   organization_unit: "devops"  # (Required) The unit within the organization
+#   environment_type: "production" # (Required) The type of environment (e.g. production, staging)
+#   environment_name: "prod"      # (Required) The name of the environment
 variable "org" {
   description = "Organization details"
   type = object({
@@ -31,6 +40,8 @@ variable "org" {
   })
 }
 
+# extra_tags: # (Optional) Extra tags to add to the resources. Default: {}
+#   Tag1: "Value1"
 variable "extra_tags" {
   description = "Extra tags to add to the resources"
   type        = map(string)

--- a/versions.tf
+++ b/versions.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.4"
+      version = "~> 6.35"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace deprecated `aws_region` `id` references with the `region` attribute
- Raise the AWS provider constraint to the validated v6.35 floor
- Refresh generated Terraform provider documentation
- Align root variable comments with YAML-style operator guidance

## Review & Validation

- `make fmt`
- `make lint` (OpenTofu v1.11.4, AWS provider v6.51.0, `tofu validate` success)
- Independent code-reviewer follow-up: APPROVE, no remaining issues
- Independent architecture follow-up: CLEAR

+semver: fix